### PR TITLE
fix huobi response

### DIFF
--- a/exchange/huobi.go
+++ b/exchange/huobi.go
@@ -3,12 +3,13 @@ package exchange
 import (
 	"encoding/json"
 	"errors"
-	"github.com/sirupsen/logrus"
 	"math"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // https://github.com/huobiapi/API_Docs/wiki/REST_api_reference
@@ -47,7 +48,7 @@ func (resp *huobiTickerResponse) getCommonResponse() huobiCommonResponse {
 type huobiKlineResponse struct {
 	huobiCommonResponse
 	Data []struct {
-		Open float64
+		Open interface{}
 	}
 }
 
@@ -105,7 +106,14 @@ func (client *huobiClient) GetKlinePrice(symbol, period string, size int) (float
 	if err != nil {
 		return 0, err
 	}
-	return respJSON.Data[len(respJSON.Data)-1].Open, nil
+	var open float64
+	if r, ok := respJSON.Data[len(respJSON.Data)-1].Open.(float64); ok {
+		open = r
+	}
+	if r, ok := respJSON.Data[len(respJSON.Data)-1].Open.(string); ok {
+		open, _ = strconv.ParseFloat(r, 64)
+	}
+	return open, nil
 }
 
 func (client *huobiClient) GetSymbolPrice(symbol string) (*SymbolPrice, error) {


### PR DESCRIPTION
huobi's kline api return two type, and it cause a bug:
```
WARN[13:33:26] Huobi - Failed to get price 1 hour ago, error: json: cannot unmarshal string into Go struct field .Open of type float64

WARN[13:33:26] Huobi - Failed to get price 24 hours ago, error: json: cannot unmarshal string into Go struct field .Open of type float64

--------------------------------------------------------------------
| Symbol  | Price | %Change(1h) | %Change(24h) | Source | Updated  |
--------------------------------------------------------------------
| EOSUSDT |  5.05 |             |              | Huobi  | 13:33:24 |
--------------------------------------------------------------------
```

![jietu20180906-135123](https://user-images.githubusercontent.com/20315934/45137600-fc152b00-b1db-11e8-9815-3382c36ff2b2.jpg)
